### PR TITLE
Session per tab support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,3 @@ language: java
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
-  - openjdk6
-

--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ The sample above is the most common pattern used when calling the create method.
 ## sebimal changes
 I've added tabid header support. If tabid header is recieved from server http response then it is stored in browser session storage and sent back to the server in the future requests.
 
-Additionally I've improved look of API response page - it has now two new buttons: for going back to the parameters and for resending data to the server again (in polish for now :P).
+Additionally I've improved look of API response page - it has now two new buttons: for going back to the parameters and for resending data to the server again.
 
 WARNING! jaxygen-apibrowser module source is now JDK1.8!

--- a/jaxygen-apibrowser/pom.xml
+++ b/jaxygen-apibrowser/pom.xml
@@ -42,8 +42,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <compilerArguments>
                         <endorseddirs>${endorsed.dir}</endorseddirs>
                     </compilerArguments>

--- a/jaxygen-apibrowser/src/main/java/org/jaxygen/apibrowser/pages/MethodInvokerPage.java
+++ b/jaxygen-apibrowser/src/main/java/org/jaxygen/apibrowser/pages/MethodInvokerPage.java
@@ -127,7 +127,7 @@ public class MethodInvokerPage extends Page {
     page.append((HTMLElement) () -> {
       StringBuilder sb = new StringBuilder("<script type=\"text/javascript\">");
       sb.append("  function sendData() {\n")
-              .append("  document.getElementById(\"queryResult\").innerHTML='Czekaj...';\n")
+              .append("  document.getElementById(\"queryResult\").innerHTML='Wait...';\n")
               .append("  document.getElementById(\"responseDiv\").style.display='block'\n")
               .append("  document.getElementById(\"mainDiv\").style.display='none';\n")
               .append("  var form = document.getElementById(\"submitForm\");\n")
@@ -165,9 +165,9 @@ public class MethodInvokerPage extends Page {
       sb.append("  function updateProgress(event) {\n")
               .append("   if (event.lengthComputable) {\n")
               .append("     var percentageComplete = event.loaded*100 / event.total;\n")
-              .append("     document.getElementById(\"queryResult\").innerHTML='Pobieranie: ' + percentageComplete + '%';\n")
+              .append("     document.getElementById(\"queryResult\").innerHTML='Downloading: ' + percentageComplete + '%';\n")
               .append("   } else {\n")
-              .append("     document.getElementById(\"queryResult\").innerHTML='Pobieranie pliku...';\n")
+              .append("     document.getElementById(\"queryResult\").innerHTML='Downloading file...';\n")
               .append("   }\n")
               .append(" }");
       sb.append("</script>");
@@ -194,12 +194,12 @@ public class MethodInvokerPage extends Page {
     });
     HTMLInput backButton = new HTMLInput();
     backButton.setType(HTMLInput.Type.button);
-    backButton.setValue("Wróć");
+    backButton.setValue("Back");
     backButton.setAttribute("onClick", "goBack()");
     responseDiv.append(backButton);
     HTMLInput retryButton = new HTMLInput();
     retryButton.setType(HTMLInput.Type.button);
-    retryButton.setValue("Prześlij ponownie");
+    retryButton.setValue("Resend request");
     retryButton.setAttribute("onClick", "sendData()");
     responseDiv.append(retryButton);
     HTMLParagraph responseQueryResult = new HTMLParagraph("queryResult");

--- a/pom.xml
+++ b/pom.xml
@@ -66,13 +66,6 @@
             <artifactId>commons-io</artifactId>
             <version>1.3.2</version>
         </dependency>
-        
-        <dependency>
-            <groupId>org.xhtmlrenderer</groupId>
-            <artifactId>core-renderer</artifactId>
-            <version>R8pre2</version>
-        </dependency>
-
 
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
I've added 'tabid' header support. If tabid header is recieved from server http response then it is stored in browser session storage and sent back to the server in the future requests.

Additionally I've improved look of API response page - it has now two new buttons: for going back to the parameters and for resending data to the server again.

xhtmlrenderer library dependency removed.