### PR TITLE
Added Serializable to SecurityProfile because in Java 1.8 APIBrowser …

### DIFF
--- a/jaxygen-core/src/main/java/org/jaxygen/security/SecurityProfile.java
+++ b/jaxygen-core/src/main/java/org/jaxygen/security/SecurityProfile.java
@@ -1,12 +1,13 @@
 package org.jaxygen.security;
 
+import java.io.Serializable;
 import org.jaxygen.security.basic.SecuredMethodDescriptor;
 
 /**Implementation of this class tells to the application container if the given method is secured.
  *
  * @author artur
  */
-public interface SecurityProfile {
+public interface SecurityProfile extends Serializable {
     /**Returns an array of user profiles bound to this provider.
      * 
      * @return List of user groups.


### PR DESCRIPTION
Please aply this patch to avoid null on login method